### PR TITLE
Updating social share buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,12 @@ Your personal social network settings are combined with the social sharing optio
 ```yml
 social:
   - name: Twitter                         # Name of the service
-    icon: twitter                  		  # Font Awesome icon to use (minus fa- prefix)
-    username: "@TheBenCentra"             # (User) Name to display in the footer link
+    icon: twitter                         # Font Awesome icon to use (minus fa- prefix)
+    username: TheBenCentra                # (User) Name to display in the footer link
     url: https://twitter.com/TheBenCentra # URL of your profile (leave blank to not display in footer)
     desc: Follow me on Twitter            # Description to display as link title, etc
-    share_url: http://twitter.com/share   # URL for sharing to the service (leave blank to disable sharing)
-    share_title: ?text=                   # Title parameter for sharing URL
-    share_link: "&amp;url="               # Link parameter for sharing URL
+    share: true                           # Include in the "Share" section of posts
 ```
-
-Any of the __share__ prefixed options are used in blog posts for the social share bar. The other options are used in the Contact info section of the footer.
 
 ### Social Protocols
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ name: Ben Centra
 description: > 
   A simple yet classy theme for your Jekyll website or blog.
 baseurl: "/centrarium/" # the subpath of your site, e.g. /blog/
-url: "http://bencentra.com" # the base hostname & protocol for your site
+url: "http://bencentra.github.io" # the base hostname & protocol for your site
 cover: "assets/header_image.jpg"
 logo: "assets/logo.png"
 
@@ -64,120 +64,101 @@ descriptions:
 social:
   - name: Twitter
     icon: twitter
-    username: "@TheBenCentra"
+    username: TheBenCentra
     url: https://twitter.com/TheBenCentra
     desc: Follow me on Twitter
-    share_url: http://twitter.com/share
-    share_title: ?text=
-    share_link: "&amp;url="
+    share: true
 
   - name: Facebook
     icon: facebook
     username: thebencentra
     url: 
     desc: Friend me on Facebook
-    share_url: //www.facebook.com/sharer.php
-    share_title: ?t=
-    share_link: "&amp;u="
+    share: true
 
   - name: GitHub
     icon: github
     username: bencentra
     url: https://github.com/bencentra
     desc: Fork me on GitHub
-    share_url:
-    share_title:
-    share_link:
+    share: false
 
   - name: LinkedIn
     icon: linkedin
     username: Ben Centra
     url: https://www.linkedin.com/pub/ben-centra/47/769/60a
     desc: Connect with me on LinkedIn
-    share_url: //www.linkedin.com/shareArticle
-    share_title: ?mini=true
-    share_link: "&amp;url="
+    share: true
 
   - name: Google+
     icon: google-plus
     username: 
     url: 
     desc: Add me to your Circles
-    share_url: //plus.google.com/share
-    share_title: ?title=
-    share_link: "&amp;url="
+    share: true
 
   - name: YouTube
     icon: youtube
     username: 
     url: 
     desc: Subscribe on YouTube
-    share_url: 
-    share_title: 
-    share_link:
+    share: false
 
   - name: Instagram
     icon: instagram
     username: 
     url: 
     desc: Follow me on Instagram
-    share_url: 
-    share_title: 
-    share_link:
+    share: false
 
   - name: Pinterest
     icon: pinterest
     username: 
     url: 
     desc: Follow me on Pinterest
-    share_url: 
-    share_title: 
-    share_link:
+    share: true
 
   - name: SoundCloud
     icon: soundcloud
     username: 
     url: 
     desc: Follow me on SoundCloud
-    share_url: 
-    share_title: 
-    share_link:
+    share: false
 
   - name: Tumblr
     icon: tumblr
     username: 
     url: 
     desc: Follow me on Tumblr
-    share_url: 
-    share_title: 
-    share_link:
+    share: false
 
   - name: Steam
     icon: steam
     username: 
     url: 
     desc: Friend me on Steam
-    share_url: 
-    share_title: 
-    share_link:
+    share: false
 
   - name: Dribbble
     icon: dribbble
     username: 
     url: 
     desc: Follow me on Dribble
+    share: false
 
   - name: Vimeo
     icon: vimeo-square
     username: 
     url: 
     desc: Follow me on Vimeo
+    share: false
 
   - name: Vine
     icon: vine
     username: 
     url: 
     desc: Follow me on Vine
+    share: false
 
 # Social sharing protocols
 # These are for automatically generating sharing metadata for FB and Twitter

--- a/_config.yml
+++ b/_config.yml
@@ -58,9 +58,7 @@ descriptions:
 #     username: "@TheBenCentra"             # (User) Name to display in the footer link
 #     url: https://twitter.com/TheBenCentra # URL of your profile (leave blank to not display in footer)
 #     desc: Follow me on Twitter            # Description to display as link title, etc
-#     share_url: http://twitter.com/share   # URL for sharing to the service (leave blank to not allow sharing)
-#     share_title: ?text=                   # Title parameter for sharing URL
-#     share_link: "&amp;url="               # Link parameter for sharing URL
+#     share: true                           # Include in the "Share" section of posts
 social:
   - name: Twitter
     icon: twitter

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
 
     <div class="site-contact">
 
-    	<p><strong>Contact</strong>
+    	<p><strong>Contact</strong></p>
       <ul class="social-media-list">
       	<li>
       		<a href="mailto:{{ site.email }}">
@@ -28,14 +28,14 @@
       	</li>
 
       	{% for social in site.social %}
-      	{% if social.url != null %}
-      	<li>
-          <a href="{{ social.url }}" title="{{ social.desc }}">
-            <i class="fa fa-{{ social.icon }}"></i>
-            <span class="username">{% if social.username %}{{ social.username }}{% else %}{{ social.name }}{% endif %}</span>
-          </a>
-        </li>
-      	{% endif %}
+	      	{% if social.url != null %}
+	      	<li>
+	          <a href="{{ social.url }}" title="{{ social.desc }}">
+	            <i class="fa fa-{{ social.icon }}"></i>
+	            <span class="username">{% if social.username %}{{ social.username }}{% else %}{{ social.name }}{% endif %}</span>
+	          </a>
+	        </li>
+	      	{% endif %}
       	{% endfor %}
 
       </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,14 +47,6 @@ layout: default
 
 <section class="share">
   <span>Share: </span>
-  <!-- {% for social in site.social %}
-    {% if social.share_url != null %}
-      <a href="{{ social.share_url }}{{ social.share_title }}{{page.title | cgi_escape}}{{ social.share_link }}{{site.url}}{{page.id}}.html"
-        onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
-      	<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
-      </a>
-    {% endif %}
-  {% endfor %} -->
   {% for social in site.social %}
   	{% if social.name == "Twitter" and social.share == true %}
   		<a href="//twitter.com/share?text={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html&via={{social.username}}"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -47,13 +47,45 @@ layout: default
 
 <section class="share">
   <span>Share: </span>
-  {% for social in site.social %}
+  <!-- {% for social in site.social %}
     {% if social.share_url != null %}
       <a href="{{ social.share_url }}{{ social.share_title }}{{page.title | cgi_escape}}{{ social.share_link }}{{site.url}}{{page.id}}.html"
         onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
       	<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
       </a>
     {% endif %}
+  {% endfor %} -->
+  {% for social in site.social %}
+  	{% if social.name == "Twitter" and social.share == true %}
+  		<a href="//twitter.com/share?text={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html&via={{social.username}}"
+  			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
+  			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
+  		</a>
+  	{% endif %}
+  	{% if social.name == "Facebook" and social.share == true %}
+  		<a href="//www.facebook.com/sharer.php?t={{ page.title | cgi_escape }}&u={{ site.url | append: site.baseurl }}{{ page.id }}.html"
+  			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
+  			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
+  		</a>
+  	{% endif %}
+  	{% if social.name == "Google+" and social.share == true %}
+  		<a href="//plus.google.com/share?title={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html"
+  			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
+  			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
+  		</a>
+  	{% endif %}
+  	{% if social.name == "LinkedIn" and social.share == true %}
+  		<a href="//www.linkedin.com/shareArticle?mini=true&url={{ site.url | append: site.baseurl }}{{ page.id }}.html"
+  			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
+  			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
+  		</a>
+  	{% endif %}
+  	<!-- {% if social.name == "Pinterest" and social.share == true %}
+  		<a href="//www.pinterest.com/pin/create/button/?description={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html{% if page.cover %}&media={{ site.url }}{{ page.cover | prepend: site.baseurl  }}{% endif %}"
+  			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
+  			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
+  		</a>
+  	{% endif %} -->
   {% endfor %}
 </section>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -80,12 +80,12 @@ layout: default
   			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
   		</a>
   	{% endif %}
-  	<!-- {% if social.name == "Pinterest" and social.share == true %}
-  		<a href="//www.pinterest.com/pin/create/button/?description={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html{% if page.cover %}&media={{ site.url }}{{ page.cover | prepend: site.baseurl  }}{% endif %}"
+  	{% if social.name == "Pinterest" and social.share == true %}
+  		<a href="//www.pinterest.com/pin/create/button/?description={{ page.title | cgi_escape }}&url={{ site.url | append: site.baseurl }}{{ page.id }}.html&media={{ site.url }}{% if page.cover %}{{ page.cover | prepend: site.baseurl  }}{% elsif site.cover %}{{ site.cover | prepend: site.baseurl }}{% else %}{{ site.logo | prepend: site.baseurl }}{% endif %}"
   			onclick="window.open(this.href, '{{ social.icon }}-share', 'width=550,height=255');return false;">
   			<i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
   		</a>
-  	{% endif %} -->
+  	{% endif %}
   {% endfor %}
 </section>
 


### PR DESCRIPTION
Each social share button is now generated separately, allowing for more customization. For instance, the Twitter button now specifies the "via" param, which will include your Twitter handle in the share box. 

This also adds Pinterest to the list of share buttons.