### PR TITLE
Prevent the word 'in' appearing for posts with no categories.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,7 @@ layout: default
 <section class="post-meta">
   <div class="post-date">{{ page.date | date: "%B %-d, %Y" }}</div>
   <div class="post-categories">
-  {% if page.categories %}in {% for cat in page.categories %}
+  {% if page.categories.size > 0 %}in {% for cat in page.categories %}
     {% if site.jekyll-archives %}
     <a href="{{ site.baseurl }}/category/{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
     {% else %}

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ layout: default
     <section class="post-meta">
       <div class="post-date">{{ post.date | date: "%B %-d, %Y" }}</div>
       <div class="post-categories">
-      {% if post.categories %}in {% for cat in post.categories %}
+      {% if post.categories.size > 0 %}in {% for cat in post.categories %}
         {% if site.jekyll-archives %}
         <a href="{{ site.baseurl }}/category/{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
         {% else %}


### PR DESCRIPTION
A user may wish to refrain from adding categories to their blog posts. One instance in which this situation may arise is when deploying a jekyll blog to GitHub Pages, as the jekyll-archives gem which makes good use of the categories isn't available.

## Before
### Index
<img width="825" alt="index-broken" src="https://cloud.githubusercontent.com/assets/1518405/11898159/f6d9af72-a5e9-11e5-8493-5efe1478713a.png">
### Post
<img width="813" alt="post-broken" src="https://cloud.githubusercontent.com/assets/1518405/11898162/f8526560-a5e9-11e5-8536-63a8ec64db30.png">

## After
### Index
<img width="833" alt="index-fixed" src="https://cloud.githubusercontent.com/assets/1518405/11898174/08cceef6-a5ea-11e5-9cbd-d96545264295.png">
### Post
<img width="793" alt="post-fixed" src="https://cloud.githubusercontent.com/assets/1518405/11898175/0a08006c-a5ea-11e5-98c0-cde276fb41e6.png">
