### PR TITLE
Fixed issue with Pagination where navigating to the first page caused a 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ layout: default
     <span class="page-number">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
     {% if paginator.previous_page %}
       {% if paginator.page == 2 %}
-      <a class="newer-posts" href="{% if site.baseurl %}{{ site.baseurl }}{% else %}/{% endif %}">
+      <a class="newer-posts" href="{% if site.baseurl %}{{ site.baseurl }}{% endif %}/">
         <span class="fa-stack fa-lg">
           <i class="fa fa-square fa-stack-2x"></i>
           <i class="fa fa-angle-double-right fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
The pagination code used an if statement to determine whether to head to the site's baseurl when the user was look at page 2 and wanting to view the posts on the main page.
This left off the the trailing slash, which would cause a 404 when navigating from the second page to the first page.

Tested by adding a number of dummy posts and navigating through the pages. Going to pages to display older posts worked as expected, as did moving forward to view newer posts, until attempting to reach the newest posts from page 2.