### PR TITLE
Remove underline from left pagination link

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -228,6 +228,9 @@ pre code.hljs {
 		.page-number {
 			padding: 0 1em;
 		}
+        a.newer-posts {
+            text-decoration: none;
+        }
 	}
 	.site-header-container {
 		color: $white;


### PR DESCRIPTION
Removes the underline that extends past the left pagination link's border. Before: 

![screen shot 2016-06-09 at 3 06 34 pm](https://cloud.githubusercontent.com/assets/4837429/15943124/80ba8f56-2e55-11e6-8262-eded8ed1c09d.png)

After:

![screen shot 2016-06-09 at 3 09 46 pm](https://cloud.githubusercontent.com/assets/4837429/15943150/a53bb602-2e55-11e6-81ac-661e90451480.png)
