### PR TITLE
Increase the libraries(Font Awesome, HighlightJS) version

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,8 +11,8 @@
   {% endif %}
 
   <!-- External libraries -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/styles/{{ site.highlightjs_theme }}.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/{{ site.highlightjs_theme }}.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css">
 
   <!-- Favicon and other icons (made with http://www.favicon-generator.org/) -->


### PR DESCRIPTION
Increase the libraries version to use some newer icons and highlight theme.
(I tried to use 'atom-one-dark' theme with older version, but I couldn't.)

ref:

- https://highlightjs.org/
- http://fontawesome.io/

Please forgive me my lousy English.