### PR TITLE
add link to categories without jekyll-archives

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,11 +23,11 @@ layout: default
     {% if site.jekyll-archives %}
     <a href="{{ site.baseurl }}/category/{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
     {% else %}
-    <span>{{ cat | capitalize }}</span>{% if forloop.last == false %}, {% endif %}
+    <a href="{{ site.baseurl }}/posts/#{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
     {% endif %}
   {% endfor %}{% endif %}
   </div>
-</section>  
+</section>
 
 <article class="post-content">
   {{ content }}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ layout: default
         {% if site.jekyll-archives %}
         <a href="{{ site.baseurl }}/category/{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
         {% else %}
-        <span>{{ cat | capitalize }}</span>{% if forloop.last == false %}, {% endif %}
+        <a href="{{ site.baseurl }}/posts/#{{ cat }}">{{ cat | capitalize }}</a>{% if forloop.last == false %}, {% endif %}
         {% endif %}
       {% endfor %}{% endif %}
       </div>

--- a/posts.html
+++ b/posts.html
@@ -6,7 +6,7 @@ permalink: /posts/
 
 {% for category in site.categories %}
   {% capture cat %}{{ category | first }}{% endcapture %}
-  <h2>{{ cat | capitalize }}</h2>
+  <h2 id="{{cat}}">{{ cat | capitalize }}</h2>
   {% for desc in site.descriptions %}
     {% if desc.cat == cat %}
       <p class="desc"><em>{{ desc.desc }}</em></p>


### PR DESCRIPTION
With jekyll-archives is not installed, creates an anchor to each category on the posts page