### PR TITLE
Feature: add page-specific js files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ If you're just getting started with Jekyll, you can use this repository as a sta
 
 If your site already uses Jekyll, follow these steps:
 
-1. Replace the files in the `_includes`, `_layouts`, and `_sass` directories with those from this project.  
-2. Replace your `index.html` with the one from this project, and copy over the `posts.html` file as well.  
-3. Copy the contents of the `_config.yml` from this project in to yours, and update the necessary information.  
+1. Replace the files in the `_includes`, `_layouts`, and `_sass` directories with those from this project.
+2. Replace your `index.html` with the one from this project, and copy over the `posts.html` file as well.
+3. Copy the contents of the `_config.yml` from this project in to yours, and update the necessary information.
 
 Don't forget to install Jekyll and other dependencies:
 ```bash
@@ -179,6 +179,31 @@ You can enhance the `posts.html` archive page with descriptions of your post cat
 descriptions:
   - cat: jekyll
     desc: "Posts describing Jekyll setup techniques."
+```
+
+### Custom Page-Specific Javascript
+
+You can add page-specific javascript files by adding them to the top-level `/js` directory and including the filename in the __custom_js__ page's configuration file:
+
+```yml
+# Custom js (for individual pages)
+---
+layout: post
+title:  "Dummy Post"
+date:   2015-04-18 08:43:59
+author: Ben Centra
+categories: Dummy
+custom_js:
+- Popmotion
+- Vue
+---
+```
+
+The `/js/` directory would contain the corresponding files:
+
+```bash
+$ ls js/
+Popmotion.js Vue.js
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can enable basic [Google Analytics][ga] pageview tracking by including your 
 
 ### Social Settings
 
-Your personal social network settings are combined with the social sharing options. In the __social__ seciton of `_config.yml`, include an entry for each network you want to include. For example:
+Your personal social network settings are combined with the social sharing options. In the __social__ section of `_config.yml`, include an entry for each network you want to include. For example:
 
 ```yml
 social:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
     <h3 class="footer-heading">{{ site.title }}</h3>
 
     <div class="site-navigation">
-      
+
       <p><strong>Site Map</strong></p>
       <ul class="pages">
         {% for page in site.pages %}
@@ -54,11 +54,10 @@
 <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js"></script>
-<script>
 
+<script type="text/javascript">
 $(document).ready(function() {
-
-  // Syntax highlighting
+  // Default syntax highlighting
   hljs.initHighlightingOnLoad();
 
   // Header
@@ -72,11 +71,16 @@ $(document).ready(function() {
       }
     });
   });
-
-
 });
 
 </script>
+
+{% if page.custom_js %}
+<!-- Custom page specific js files -->
+  {% for js_file in page.custom_js %}
+    <script src='/js/{{ js_file }}.js' type="text/javascript"></script>
+  {% endfor %}
+{% endif %}
 
 {% if site.ga_tracking_id %}
 <!-- Google Analytics -->


### PR DESCRIPTION
Hey Ben,

I have been using your theme on my github pages and came across wanting to have a page-specific js file added to one of my posts.

I made a PR to add this functionality to Centrarium, also fixed a typo and eliminated some extra whitespace.