### PR TITLE
Add Hacker News as a share option.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -175,6 +175,13 @@ social:
     desc: Share to Reddit
     share: true
 
+  - name: "Hacker News"
+    icon: hacker-news
+    username:
+    url:
+    desc: Share to Hacker News
+    share: false
+
 # Social sharing protocols
 # These are for automatically generating sharing metadata for FB and Twitter
 # OS Protocol is for sharing the source of your site, if you're interested. For more, see osprotocol.com

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -84,6 +84,11 @@ layout: default
         <i class="fa fa-{{ social.icon | remove_first: '-square' }}-square fa-lg"></i>
       </a>
     {% endif %}
+    {% if social.name == "Hacker News" and social.share == true %}
+      <a href="//news.ycombinator.com/submitlink" onclick="window.location = '//news.ycombinator.com/submitlink?u=' + encodeURIComponent('{{ full_url }}') + '&t={{page.title}}'; return false">
+        <i class="fa fa-{{ social.icon | remove_first: '-square' }} fa-lg"></i>
+      </a>
+    {% endif %}
   {% endfor %}
 </section>
 {% if site.inter_post_navigation == true %}


### PR DESCRIPTION
I've left this disabled by default as it is generally only relevant to technology focused bloggers. 💻 :octocat: