### PR TITLE
Add condition to the posts layout to disable disqus when running in development

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -113,7 +113,7 @@ layout: default
 	</section>
 {% endif %}
 
-{% if site.disqus_shortname %}
+{% if site.disqus_shortname and jekyll.environment != "development" %}
 {% unless page.disqus_disabled %}
 <section class="disqus">
   <div id="disqus_thread"></div>


### PR DESCRIPTION
Without this conditional running whenever writing on draft pages new threads can be made in disqus, polluting the list of threads in the disqus administration panels.