### PR TITLE
fix sort-reverse from jekyll-paginate-v2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ pagination:
   enabled: true
   per_page: 5
   permalink: "/page/:num/"
+  sort_reverse: true
 
 # Archive settings (see https://github.com/jekyll/jekyll-archives/)
 jekyll-archives:

--- a/_posts/2015-04-19-dummy6.markdown
+++ b/_posts/2015-04-19-dummy6.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Dummy Post 6"
-date:   2015-04-18 08:43:59
+date:   2015-04-19 08:43:59
 author: Ben Centra
 categories: Dummy
 tags: lorem ipsum

--- a/_posts/2015-04-20-welcome-to-jekyll.markdown
+++ b/_posts/2015-04-20-welcome-to-jekyll.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Welcome to Jekyll!"
-date:   2015-04-18 08:43:59
+date:   2015-04-20 08:43:59
 author: Ben Centra
 categories: Jekyll
 tags:	jekyll welcome


### PR DESCRIPTION
* Fixes a bug after upgrading to Jekyll 3/jekyll-paginate-v2 in which the default sort order was backward. Technically it was forward, but it was backward from what it should be :)
* Changes the publish date on some example pages to demonstrate the behavior.