### PR TITLE
Add JS Licenses

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,6 @@
 <footer class="site-footer">
-
+<a href="/about/javascript" data-jslicense="1">JavaScript license information</a>
+	
   <div class="wrapper">
 
     <h3 class="footer-heading">{{ site.title }}</h3>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -55,6 +55,7 @@
 <script src="//unpkg.com/tippy.js@5"></script>
 
 <script type="text/javascript">
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
 $(document).ready(function() {
   // Default syntax highlighting
   hljs.initHighlightingOnLoad();
@@ -80,7 +81,7 @@ $(document).ready(function() {
 		})
 	}
 });
-
+// @license-end
 </script>
 
 {% if page.custom_js %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -94,6 +94,7 @@ $(document).ready(function() {
 {% if site.ga_tracking_id %}
 <!-- Google Analytics -->
 <script>
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -103,5 +104,6 @@ $(document).ready(function() {
     'page': '{{ page.url }}',
     'title': '{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}'
   });
+// @license-end
 </script>
 {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer">
-<a href="/about/javascript" data-jslicense="1">JavaScript license information</a>
+<a href="/javascript" data-jslicense="1">JavaScript license information</a>
 	
   <div class="wrapper">
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -73,6 +73,8 @@
 	
 	<!-- Tooltips -->
 	<script type="text/javascript">
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
 		window.tooltips = []
+// @license-end
 	</script>
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -123,6 +123,7 @@ layout: default
 <section class="disqus">
   <div id="disqus_thread"></div>
   <script type="text/javascript">
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
     var disqus_shortname = '{{ site.disqus_shortname }}';
 
     /* * * DON'T EDIT BELOW THIS LINE * * */
@@ -131,6 +132,7 @@ layout: default
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
+// @license-end
   </script>
   <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
   <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>

--- a/_posts/2015-04-20-welcome-to-jekyll.markdown
+++ b/_posts/2015-04-20-welcome-to-jekyll.markdown
@@ -97,7 +97,9 @@ Check out the [Jekyll docs][jekyll] for more info on how to get the most out of 
 [liquid]: https://github.com/Shopify/liquid/wiki/Liquid-for-Designers
 
 <script>
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt Expat
 window.tooltips = window.tooltips || []
 window.tooltips.push(['#someId', { content: "This is the text of the tooltip!" }])
 window.tooltips.push(['#someOtherId', { content: "{% include tooltips/example.html %}", placement: "right" }])
+// @license-end
 </script>

--- a/javascript.html
+++ b/javascript.html
@@ -1,0 +1,23 @@
+    <table id="jslicense-labels1">
+        <tr>
+            <td><a href="//code.jquery.com/jquery-3.4.1.min.js">jquery-2.1.1.min.js</a></td>
+            <td><a href="https://jquery.org/license/">Expat</a></td>
+        </tr>
+        <tr>
+            <td><a href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js">highlight.min.js</a></td>
+            <td><a href="http://git.io/hljslicense">BSD-3-clause</a></td>
+        </tr>
+        <tr>
+            <td><a href="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.11.1/js/lightbox.min.js">lightbox.min.js</a></td>
+            <td><a href="https://github.com/lokesh/lightbox2/blob/master/LICENSE">Expat</a></td>
+        </tr>
+        <tr>
+            <td><a href="//unpkg.com/popper.js@1">popper.js@1</a></td>
+            <td><a href="http://opensource.org/licenses/MIT">Expat</a></td>
+        </tr>
+        </tr>
+        <tr>
+            <td><a href="//unpkg.com/tippy.js@5">popper.js@5</a></td>
+            <td><a href="https://unpkg.com/browse/tippy.js@5.2.1/LICENSE">Expat</a></td>
+        </tr>
+    </table>


### PR DESCRIPTION
The GNU Project has a standard for listing JS licenses on websites.

https://www.gnu.org/software/librejs/manual/html_node/Setting-Your-JavaScript-Free.html

This should properly license all of it.

___________________________________

Based on: https://notabug.org/EPuters/EPuters.net/issues/1