### PR TITLE
Fix unclosed `<li>`

### DIFF
--- a/_includes/nav_links.html
+++ b/_includes/nav_links.html
@@ -1,5 +1,7 @@
 {% for page in site.pages %}
 	{% if page.title and page.main_nav == true %}
-	<li class="nav-link"><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-	{% endif %}
+	<li class="nav-link">
+        <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+    </li>
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
The `<li class="nav-link">` tag seems to be unclosed in `nav_links.html`