### PR TITLE
Update Font Awesome version to 6.6.0

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
       <ul class="social-media-list">
         <li>
           <a href="mailto:{{ site.email }}">
-            <i class="fa fa-envelope-o"></i>
+            <i class="fa-regular fa-envelope"></i>
             <span class="username">{{ site.email }}</span>
           </a>
         </li>
@@ -27,7 +27,7 @@
           {% if social.url != "" %}
           <li>
             <a href="{{ social.url }}" title="{{ social.desc }}">
-              <i class="fa fa-{{ social.icon }}"></i>
+              <i class="fa-brands fa-{{ social.icon }}"></i>
               <span class="username">{% if social.username %}{{ social.username }}{% else %}{{ social.name }}{% endif %}</span>
             </a>
           </li>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <!-- External libraries -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/{{ site.highlightjs_theme }}.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css">
 


### PR DESCRIPTION
Font Awesome 4.6.3 is quite old now and doesn't include many newer icons. I propose to upload it to 6.6.0 (newest version as of today). I also modified the `footer.html` to use the icons' names in the newer version.

I used CDNJS for CDN: https://cdnjs.com/libraries/font-awesome